### PR TITLE
library(grid) call at the R script header

### DIFF
--- a/public/java/src/org/broadinstitute/sting/gatk/walkers/variantrecalibration/VariantRecalibrator.java
+++ b/public/java/src/org/broadinstitute/sting/gatk/walkers/variantrecalibration/VariantRecalibrator.java
@@ -372,6 +372,8 @@ public class VariantRecalibrator extends RodWalker<ExpandingArrayList<VariantDat
         stream.println("library(ggplot2)");
         // For compactPDF in R 2.13+
         stream.println("library(tools)");
+        // For graphical functions R 2.14.2+
+        stream.println("library(grid)");
 
         createArrangeFunction( stream );
 


### PR DESCRIPTION
I've simply added a "library(grid)" call at the beginning of the R script generation since R 2.14.2 doesn't seem to load the "grid" package as default. I haven't tested it on previous R versions (you may edit the R version comment to be more precise if desired), but I'm almost certain that this library call shouldn't do any harm on them.
