### PR TITLE
Bug fix for Queue LSF v8.3 

### DIFF
--- a/public/java/src/org/broadinstitute/sting/jna/lsf/v7_0_6/LibLsf.java
+++ b/public/java/src/org/broadinstitute/sting/jna/lsf/v7_0_6/LibLsf.java
@@ -1399,7 +1399,10 @@ public class LibLsf {
 
     public static native int ls_isPartialLicensingEnabled();
 
-    public static native lsfLicUsage.ByReference ls_getLicenseUsage();
+    /* NOTE: ls_getLicenseUsage() is not supported by LSF v8.x
+    *  Wei Xing, ICR
+    */
+//    public static native lsfLicUsage.ByReference ls_getLicenseUsage();
 
     public static native lsInfo.ByReference ls_info();
 


### PR DESCRIPTION
the function ls_getLicenseUsage() is not supported by LSF v8.x, comment the line: 

public static native lsfLicUsage.ByReference ls_getLicenseUsage()
