### PR TITLE
deducing dictionary path should not use global find and replace

### DIFF
--- a/public/java/src/org/broadinstitute/sting/gatk/datasources/reference/ReferenceDataSource.java
+++ b/public/java/src/org/broadinstitute/sting/gatk/datasources/reference/ReferenceDataSource.java
@@ -68,8 +68,8 @@ public class ReferenceDataSource {
         final File indexFile = new File(fastaFile.getAbsolutePath() + ".fai");
 
         // determine the name for the dict file
-        final String fastaExt = fastaFile.getAbsolutePath().endsWith("fa") ? ".fa" : ".fasta";
-        final File dictFile = new File(fastaFile.getAbsolutePath().replace(fastaExt, ".dict"));
+        final String fastaExt = fastaFile.getAbsolutePath().endsWith("fa") ? "\\.fa$" : "\\.fasta$";
+        final File dictFile = new File(fastaFile.getAbsolutePath().replaceAll(fastaExt, ".dict"));
 
         // It's an error if either the fai or dict file does not exist. The user is now responsible
         // for creating these files.


### PR DESCRIPTION
Ran into a bug when the fasta index (".fa") was also a substring in the full path.  Small change using regular expressions to replace only the file suffix.
