### PR TITLE
[queue-engine] Expose time between checks as cli parameter

### DIFF
--- a/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraph.scala
+++ b/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraph.scala
@@ -529,7 +529,7 @@ class QGraph extends Logging {
     lastRunningCheck > 0 && nextRunningCheck(lastRunningCheck) <= 0
 
   private def nextRunningCheck(lastRunningCheck: Long) =
-    ((this.settings.time_between_checks * 1000L) - (System.currentTimeMillis - lastRunningCheck))
+    ((this.settings.time_between_checks.toLong * 1000L) - (System.currentTimeMillis - lastRunningCheck))
 
   def formattedStatusCounts: String = {
     "%d Pend, %d Run, %d Fail, %d Done".format(

--- a/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraph.scala
+++ b/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraph.scala
@@ -529,7 +529,7 @@ class QGraph extends Logging {
     lastRunningCheck > 0 && nextRunningCheck(lastRunningCheck) <= 0
 
   private def nextRunningCheck(lastRunningCheck: Long) =
-    ((30 * 1000L) - (System.currentTimeMillis - lastRunningCheck))
+    ((this.settings.time_between_checks * 1000L) - (System.currentTimeMillis - lastRunningCheck))
 
   def formattedStatusCounts: String = {
     "%d Pend, %d Run, %d Fail, %d Done".format(

--- a/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraphSettings.scala
+++ b/public/gatk-queue/src/main/scala/org/broadinstitute/gatk/queue/engine/QGraphSettings.scala
@@ -55,6 +55,9 @@ class QGraphSettings {
   @Argument(fullName="retry_failed", shortName="retry", doc="Retry the specified number of times after a command fails.  Defaults to no retries.", required=false)
   var retries = 0
 
+  @Argument(fullName="time_between_checks", shortName="tbc", doc="Seconds between checks if new jobs can be run. Default 30.", required=false)
+  var time_between_checks = 30.0
+
   @Argument(fullName="start_from_scratch", shortName="startFromScratch", doc="Runs all command line functions even if the outputs were previously output successfully.", required=false)
   var startFromScratch = false
 


### PR DESCRIPTION
This exposes the time between checks if new jobs can be submitted as a user-settable parameter on CLi. Useful when testing pipelines to make idle time shorter. 

https://twitter.com/gatk_dev/status/661715969274855424
