### PR TITLE
Initial commit for the POWER8 porting of VectorLoglessPairHMM

### DIFF
--- a/public/VectorPairHMM/src/main/c++/LoadTimeInitializer.cc
+++ b/public/VectorPairHMM/src/main/c++/LoadTimeInitializer.cc
@@ -45,9 +45,12 @@ LoadTimeInitializer::LoadTimeInitializer()		//will be called when library is loa
 {
 #if (defined(__GNUC__) || defined(__GNUG__)) && !defined(__INTEL_COMPILER)
   //compiles only with gcc >= 4.8
+#if defined(__x86_64__)
   __builtin_cpu_init();
 #endif
+#endif
   ConvertChar::init();
+#if defined(__x86_64__)
 #ifndef DISABLE_FTZ
   //Very important to get good performance on Intel processors
   //Function: enabling FTZ converts denormals to 0 in hardware
@@ -56,6 +59,7 @@ LoadTimeInitializer::LoadTimeInitializer()		//will be called when library is loa
   //cout << "FTZ enabled - may decrease accuracy if denormal numbers encountered\n";
 #else
   cout << "FTZ is not set - may slow down performance if denormal numbers encountered\n";
+#endif
 #endif
   //Profiling: times for compute and transfer (either bytes copied or pointers copied)
   m_compute_time = 0;

--- a/public/VectorPairHMM/src/main/c++/Makefile
+++ b/public/VectorPairHMM/src/main/c++/Makefile
@@ -139,7 +139,11 @@ Sandbox.class: Sandbox.java
 copied_lib: libVectorLoglessPairHMM.so
 ifdef OUTPUT_DIR
 	mkdir -p $(OUTPUT_DIR)
+ifeq ($(arch),ppc64le)
+	rsync -a libVectorLoglessPairHMM.so $(OUTPUT_DIR)/libVectorLoglessPairHMM_ppc64le.so
+else
 	rsync -a libVectorLoglessPairHMM.so $(OUTPUT_DIR)/
+endif
 endif
 
 clean:

--- a/public/VectorPairHMM/src/main/c++/Makefile
+++ b/public/VectorPairHMM/src/main/c++/Makefile
@@ -22,6 +22,11 @@
 #THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+arch=$(shell uname -m)
+ifeq ($(arch),ppc64le)
+USE_GCC=1
+DISABLE_FTZ=1
+endif
 
 #OMPCFLAGS=-fopenmp
 #OMPLFLAGS=-fopenmp #-openmp-link static
@@ -33,7 +38,7 @@ JRE_HOME?=/opt/jdk1.7.0_25/jre
 JNI_COMPILATION_FLAGS=-D_REENTRANT -fPIC -I${JRE_HOME}/../include -I${JRE_HOME}/../include/linux
 
 #COMMON_COMPILATION_FLAGS=$(JNI_COMPILATION_FLAGS) -O3 -W -Wall -pedantic $(OMPCFLAGS) -Wno-unknown-pragmas
-COMMON_COMPILATION_FLAGS=$(JNI_COMPILATION_FLAGS) -O3 -Wall $(OMPCFLAGS) -Wno-unknown-pragmas -Wno-write-strings -Wno-unused-variable -Wno-unused-but-set-variable
+COMMON_COMPILATION_FLAGS=$(JNI_COMPILATION_FLAGS) -g -O3 -Wall $(OMPCFLAGS) -Wno-unknown-pragmas -Wno-write-strings -Wno-unused-variable -Wno-unused-but-set-variable
 ifdef DISABLE_FTZ
   COMMON_COMPILATION_FLAGS+=-DDISABLE_FTZ
 endif
@@ -41,8 +46,15 @@ endif
 ifdef USE_GCC
   C_COMPILER?=gcc
   CPP_COMPILER?=g++
+ifeq ($(arch),ppc64le)
+  COMMON_COMPILATION_FLAGS+=-mcpu=power8 -mtune=power8 -fopenmp
+  OMPLDFLAGS=-lgomp
+  AVX_FLAGS=
+  SSE41_FLAGS=
+else
   AVX_FLAGS=-mavx
   SSE41_FLAGS=-msse4.1
+endif
   COMMON_COMPILATION_FLAGS+=-Wno-char-subscripts
 else
   C_COMPILER?=icc
@@ -55,7 +67,7 @@ else
   endif
 endif
 
-LDFLAGS=-lm -lrt $(OMPLDFLAGS)
+LDFLAGS=-lm -lrt -lgcc_s -lgcc $(OMPLDFLAGS)
 
 PAPI_DIR=/home/karthikg/softwares/papi-5.3.0
 ifdef USE_PAPI
@@ -72,7 +84,11 @@ DEPDIR=.deps
 DF=$(DEPDIR)/$(*).d
 
 #Common across libJNI and sandbox
+ifeq ($(arch),ppc64le)
+COMMON_SOURCES=utils.cc baseline.cc sse_function_instantiations.cc LoadTimeInitializer.cc
+else
 COMMON_SOURCES=utils.cc avx_function_instantiations.cc baseline.cc sse_function_instantiations.cc LoadTimeInitializer.cc
+endif
 #Part of libJNI
 LIBSOURCES=org_broadinstitute_gatk_utils_pairhmm_VectorLoglessPairHMM.cc org_broadinstitute_gatk_utils_pairhmm_DebugJNILoglessPairHMM.cc Sandbox.cc $(COMMON_SOURCES)
 SOURCES=$(LIBSOURCES) pairhmm-template-main.cc pairhmm-1-base.cc
@@ -93,7 +109,11 @@ SSE_OBJECTS=$(SSE_SOURCES:.cc=.o)
 $(NO_VECTOR_OBJECTS): CXXFLAGS=$(COMMON_COMPILATION_FLAGS)
 $(AVX_OBJECTS): CXXFLAGS=$(COMMON_COMPILATION_FLAGS) $(AVX_FLAGS)
 $(SSE_OBJECTS): CXXFLAGS=$(COMMON_COMPILATION_FLAGS) $(SSE41_FLAGS)
+ifeq ($(arch),ppc64le)
+OBJECTS=$(NO_VECTOR_OBJECTS) $(SSE_OBJECTS)
+else
 OBJECTS=$(NO_VECTOR_OBJECTS) $(AVX_OBJECTS) $(SSE_OBJECTS)
+endif
 
 all: $(BIN) Sandbox.class copied_lib
 

--- a/public/VectorPairHMM/src/main/c++/common_data_structure.h
+++ b/public/VectorPairHMM/src/main/c++/common_data_structure.h
@@ -2,6 +2,9 @@
 #define COMMON_DATA_STRUCTURE_H
 
 #include "headers.h"
+#if defined(__POWER8_VECTOR__)
+#include "power8.h"
+#endif
 
 #define CAT(X,Y) X####Y
 #define CONCAT(X,Y) CAT(X,Y)
@@ -29,16 +32,17 @@ template<class NUMBER>
 struct ContextBase
 {
   public:
-    NUMBER ph2pr[128];
-    NUMBER INITIAL_CONSTANT;
-    NUMBER LOG10_INITIAL_CONSTANT;
-    NUMBER RESULT_THRESHOLD; 
+    static NUMBER ph2pr[128];
+    static NUMBER INITIAL_CONSTANT;
+    static NUMBER LOG10_INITIAL_CONSTANT;
+    static NUMBER RESULT_THRESHOLD; 
 
     static bool staticMembersInitializedFlag;
+    static bool staticMembersInitializedFlag1;
     static NUMBER jacobianLogTable[JACOBIAN_LOG_TABLE_SIZE];
     static NUMBER matchToMatchProb[((MAX_QUAL + 1) * (MAX_QUAL + 2)) >> 1];
 
-    static void initializeStaticMembers()
+    static void initializeStaticMembers0()
     {
       if(!staticMembersInitializedFlag)
       {
@@ -116,7 +120,18 @@ struct Context : public ContextBase<NUMBER>
 template<>
 struct Context<double> : public ContextBase<double>
 {
-  Context():ContextBase<double>()
+  Context():ContextBase<double>() {}
+
+  static void initializeStaticMembers()
+  {
+      initializeStaticMembers0();
+      if(!staticMembersInitializedFlag1) {
+	initializePh2pr();
+	staticMembersInitializedFlag1 = true;
+      }
+  }
+
+  static void initializePh2pr()
   {
     for (int x = 0; x < 128; x++)
       ph2pr[x] = pow(10.0, -((double)x) / 10.0);
@@ -136,7 +151,18 @@ struct Context<double> : public ContextBase<double>
 template<>
 struct Context<float> : public ContextBase<float>
 {
-  Context() : ContextBase<float>()
+  Context() : ContextBase<float>() {}
+
+  static void initializeStaticMembers()
+  {
+      initializeStaticMembers0();
+      if(!staticMembersInitializedFlag1) {
+	initializePh2pr();
+	staticMembersInitializedFlag1 = true;
+      }
+  }
+
+  static void initializePh2pr()
   {
     for (int x = 0; x < 128; x++)
     {
@@ -181,6 +207,7 @@ typedef struct
 	int *ihap;
 	int *irs;
 } testcase;
+
 
 #define MIN_ACCEPTED 1e-28f
 #define NUM_DISTINCT_CHARS 5

--- a/public/VectorPairHMM/src/main/c++/headers.h
+++ b/public/VectorPairHMM/src/main/c++/headers.h
@@ -36,8 +36,10 @@
 
 #include <sys/time.h>
 
+#if defined(__x86_64__)
 #include <immintrin.h>
 #include <emmintrin.h>
+#endif
 #include <omp.h>
 
 #include <string>

--- a/public/VectorPairHMM/src/main/c++/org_broadinstitute_gatk_utils_pairhmm_VectorLoglessPairHMM.cc
+++ b/public/VectorPairHMM/src/main/c++/org_broadinstitute_gatk_utils_pairhmm_VectorLoglessPairHMM.cc
@@ -251,10 +251,22 @@ inline void compute_testcases(vector<testcase>& tc_array, unsigned numTestCases,
   for(unsigned i=0;i<10;++i)
 #endif
   {
+#if defined(__POWER8_VECTOR__)
+    extern unsigned long g_max_num_threads; 
+#pragma omp parallel for schedule (dynamic,10) num_threads(g_max_num_threads) /* 12:68.9s */
+#else
 #pragma omp parallel for schedule (dynamic,10000) num_threads(maxNumThreadsToUse)
+#endif
     for(unsigned tc_idx=0;tc_idx<numTestCases;++tc_idx)
     {
-      float result_avxf = g_compute_full_prob_float(&(tc_array[tc_idx]), 0);
+      float result_avxf; 
+#if defined(__POWER8_VECTOR__)
+      if (g_compute_full_prob_float)
+#endif
+      result_avxf = g_compute_full_prob_float(&(tc_array[tc_idx]), 0);
+#if defined(__POWER8_VECTOR__)
+      else result_avxf = 0.0f;
+#endif
       double result = 0;
       if (result_avxf < MIN_ACCEPTED) {
         double result_avxd = g_compute_full_prob_double(&(tc_array[tc_idx]), 0);

--- a/public/VectorPairHMM/src/main/c++/pairhmm-template-main.cc
+++ b/public/VectorPairHMM/src/main/c++/pairhmm-template-main.cc
@@ -25,8 +25,13 @@
 
 #include "headers.h"
 
+#if defined(__x86_64__)
 #define SIMD_ENGINE avx
 #define SIMD_ENGINE_AVX
+#elif defined(__POWER8_VECTOR__)
+#define SIMD_ENGINE sse
+#define SIMD_ENGINE_SSE
+#endif
 
 #include "utils.h"
 

--- a/public/VectorPairHMM/src/main/c++/power8.h
+++ b/public/VectorPairHMM/src/main/c++/power8.h
@@ -1,0 +1,125 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2016 IBM
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <altivec.h>
+
+typedef vector unsigned int __m128i;
+typedef vector float __m128;
+typedef vector double __m128d;
+#define _mm_add_ps(a,b) vec_add(a,b)
+#define _mm_add_pd(a,b) vec_add(a,b)
+#define _mm_sub_ps(a,b) vec_sub(a,b)
+#define _mm_sub_pd(a,b) vec_sub(a,b)
+#define _mm_div_ps(a,b) vec_div(a,b)
+#define _mm_div_pd(a,b) vec_div(a,b)
+#define _mm_mul_ps(a,b) vec_mul(a,b)
+#define _mm_mul_pd(a,b) vec_mul(a,b)
+// r := (b==0)? a32_0 : ((b==1) ? a32_1 : ((b==2) ? a32_2 : a32_3))
+#define _mm_extract_epi32(a,b) vec_extract(a,b<=3?b:3)
+// r := (b==0)? a64_0 : a64_1
+#define _mm_extract_epi64(a,b) vec_extract((vector unsigned long long)a,b<=1?b:1)
+// r0 := (c==0) ? b : a32_0
+// r1 := (c==1) ? b : a32_1
+// r2 := (c==2) ? b : a32_2
+// r3 := (c==3) ? b : a32_3
+#define _mm_insert_epi32(a,b,c) (c<=3 ? vec_insert(b,a,c) : a)
+// r0 := (c==0) ? b : a64_0
+// r1 := (c==1) ? b : a64_1
+#define _mm_insert_epi64(a,b,c) (c<=1 ? (__m128i)vec_insert(b,(vector unsigned long long)a,c) : a)
+// r0 := a32_0 << b
+// r1 := a32_1 << b
+// r2 := a32_2 << b
+// r3 := a32_3 << b
+#define _mm_slli_epi32(a,b) vec_sl(a,((__m128i){b,b,b,b}))
+// r0 := a64_0 << b
+// r1 := a64_1 << b
+#define _mm_slli_epi64(a,b) (__m128i)vec_sl((vector unsigned long long)a,((vector unsigned long long){b,b}))
+// r0 := r1 := r2 := r3 := a32
+#define _mm_set1_ps(a) ((__m128){a,a,a,a})// vec_splat((vector float){a}, 0) // http://lists.freebsd.org/pipermail/freebsd-ppc/2014-July/007110.html 
+// r0 := r1 := a64
+#define _mm_set1_pd(a) ((__m128d){a,a})// vec_splat((vector double){a}, 0)
+// r0 := a32
+// r1 := a32
+// r2 := a32
+// r3 := a32
+#define _mm_set1_epi32(a) ((__m128i){a,a,a,a})//vec_splat((__m128i){a}, 0)
+// r0 := d32
+// r1 := c32
+// r2 := b32
+// r3 := a32
+#define _mm_set_ps(a,b,c,d) ((__m128){d,c,b,a})
+// r0 := b64
+// r1 := a64
+#define _mm_set_pd(a,b) ((__m128d){b,a})
+// r0 := (float)a32_0
+// r1 := (float)a32_1
+// r2 := (float)a32_2
+// r3 := (float)a32_3
+#define _mm_cvtepi32_ps(a) vec_ctf(a,0) // http://www.filibeto.org/unix/macos/lib/dev/documentation/Performance/Conceptual/Accelerate_sse_migration/Accelerate_sse_migration.pdf
+// r0 := (double)a64_0
+// r1 := (double)a64_1
+#if defined(vec_ctd)
+#define _mm_cvtepi32_pd(a) vec_ctd(a,0) /* will be supported by a future version of gcc */
+#else
+#if __GNUC__ > 4
+#define _mm_cvtepi32_pd(a) ((__m128d){(double)vec_extract(a,0),(double)vec_extract(a,1)})
+#else
+// Some g++ cannot compile this because of "sorry, unimplemented: unexpected AST of kind compound_literal_expr"
+#if !defined(_MM_CVTEPI32_PD)
+#define _MM_CVTEPI32_PD
+extern "C" __inline __m128d _mm_cvtepi32_pd(vector unsigned int a) {
+  double const a0 = (double)vec_extract((vector unsigned long long)a,0);
+  double const a1 = (double)vec_extract((vector unsigned long long)a,1);
+  return (__m128d){a0,a1};
+}
+#endif
+#endif
+#endif
+// __m128i r := __m128i a << (int b * 8)
+#define _mm_slli_si128(a,b) \
+  (b==4?vec_perm(a,(__m128i){0,0,0,0},(vector unsigned char){ 16,16,16,16, 0,1,2,3, 4,5,6,7, 8,9,10,11 }): \
+   (b==8?vec_perm(a,(__m128i){0,0,0,0},(vector unsigned char){ 16,16,16,16, 16,16,16,16, 0,1,2,3, 4,5,6,7}): \
+	(__m128i){(exit(-1),0U)}))
+// r0 := (c32_0 & 0x80000000) ? b32_0 : a32_0
+// r1 := (c32_1 & 0x80000000) ? b32_1 : a32_1
+// r2 := (c32_2 & 0x80000000) ? b32_2 : a32_2
+// r3 := (c32_3 & 0x80000000) ? b32_3 : a32_3
+//#define _mm_blendv_ps(a,b,c) vec_sel(a,b,(vector unsigned int){((unsigned int)c[0]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[1]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[2]&0x80000000)?0xFFFFFFFF:0,((unsigned int)c[3]&0x80000000)?0xFFFFFFFF:0})
+#define _mm_blendv_ps(a,b,c) vec_sel(a,b,vec_sra((vector signed int)c, (vector unsigned int){31,31,31,31}))
+// r0 := (c64_0 & 0x80000000) ? b64_0 : a64_0
+// r1 := (c64_1 & 0x80000000) ? b64_1 : a64_1
+//#define _mm_blendv_pd(a,b,c) vec_sel(a,b,(vector unsigned long long){(c[0]&0x8000000000000000UL)?0xFFFFFFFFFFFFFFFFUL:0,(c[1]&0x8000000000000000UL)?0xFFFFFFFFFFFFFFFFUL:0})
+#define _mm_blendv_pd(a,b,c) vec_sel(a,b,vec_sra((vector signed long long)c, (vector unsigned long long){63,63}))
+//#if !defined(_MM_BLENDV_PD)
+//#define _MM_BLENDV_PD
+//extern "C" __inline vector double _mm_blendv_pd(vector double a, vector double b, vector double c) {
+//  vector signed long long c1 = (vector signed long long)c;
+//  vector unsigned long long c2 = (vector unsigned long long){63,63};
+//  vector signed long long d = vec_sra(c1, c2);
+//  return vec_sel(a, b, d);
+//}
+//#endif

--- a/public/VectorPairHMM/src/main/c++/template.h
+++ b/public/VectorPairHMM/src/main/c++/template.h
@@ -26,8 +26,11 @@
 #ifndef TEMPLATES_H_
 #define TEMPLATES_H_
 
+#if defined(__POWER8_VECTOR__)
+#include <altivec.h>
+#include "power8.h"
+#endif
 #include "headers.h"
-
 
 #define ALIGNED __attribute__((aligned(32)))
 
@@ -42,7 +45,9 @@ typedef union __attribute__((aligned(32))) {
 
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m128 ALIGNED d;
+#if defined(__x86_64__) // 64-bit width vector
         ALIGNED __m64 ALIGNED s[2];
+#endif
         ALIGNED float  ALIGNED f[4];
         ALIGNED __m128i ALIGNED i;
 } ALIGNED mix_F128 ALIGNED;
@@ -54,8 +59,10 @@ typedef union ALIGNED {
 } MaskVec_F ;
 
 typedef union ALIGNED {
+#if defined(__x86_64__) // 64-bit width vector
   __m64 vec ;
   __m64 vecf ;
+#endif
   uint32_t masks[2] ;
 } MaskVec_F128 ;
 
@@ -82,7 +89,9 @@ typedef union __attribute__((aligned(32))) {
 
 typedef union __attribute__((aligned(32))) {
         ALIGNED __m128d ALIGNED d;
+#if defined(__x86_64__) // 64-bit width vector
         ALIGNED __m64 ALIGNED s[2];
+#endif
         ALIGNED double  ALIGNED f[2];
         ALIGNED __m128i ALIGNED i;
 } ALIGNED mix_D128 ALIGNED;
@@ -94,8 +103,10 @@ typedef union ALIGNED {
 } MaskVec_D ;
 
 typedef union ALIGNED {
+#if defined(__x86_64__) // 64-bit width vector
   __m64 vec ;
   __m64 vecf ;
+#endif
   uint64_t masks[1] ;
 } MaskVec_D128 ;
 


### PR DESCRIPTION
We changed the files so that libVectorLoglessPairHMM.so can be built for POWER8 (ppc64le).
The vector primitives used in the code call POWER8 vector primitives. The porting was done
by simple macro expansion.
